### PR TITLE
Remove Cursor and Copilot references from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,6 @@ Repository guidance for coding agents working in this project.
 - Legacy stack has been removed from active runtime.
 
 ## Rules Files Check
-- Cursor rules directory `.cursor/rules/`: not present.
-- Cursor root file `.cursorrules`: not present.
 - Copilot instructions `.github/copilot-instructions.md`: not present.
 
 If these files are added later, incorporate their rules into this document.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,6 @@ Repository guidance for coding agents working in this project.
 - Legacy stack has been removed from active runtime.
 
 ## Rules Files Check
-- Copilot instructions `.github/copilot-instructions.md`: not present.
 
 If these files are added later, incorporate their rules into this document.
 


### PR DESCRIPTION
Removes Cursor- and Copilot-specific references from `AGENTS.md` while keeping the rest of the repository guidance intact.

### Changes
- removed `.cursor/rules/` note
- removed `.cursorrules` note
- removed `.github/copilot-instructions.md` note
- updated the rules-files section accordingly